### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # mcp-searxng-public
 An MCP server that queries public SearXNG instances, parsing HTML contents into a JSON result
 
+<a href="https://glama.ai/mcp/servers/@pwilkin/mcp-searxng-public">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@pwilkin/mcp-searxng-public/badge" alt="SearXNG Server MCP server" />
+</a>
+
 ## Rationale
 
 All the MCP servers for SearXNG that I've seen use "json" as the output format. While that is certainly a *faster* way to code a SearXNG MCP server, it will make it fail on virtually all public servers since they don't expose the JSON format.


### PR DESCRIPTION
This PR adds a badge for the [SearXNG MCP Server](https://glama.ai/mcp/servers/@pwilkin/mcp-searxng-public) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@pwilkin/mcp-searxng-public">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@pwilkin/mcp-searxng-public/badge" alt="SearXNG Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.